### PR TITLE
feat: 新增 commit 訊息摘要功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ commit-assistant config clear
 - Custom (個人定義給自己內部專案使用的)
   ![Custom](docs/images/custom.png)
 
+## 摘要功能
+可將指定區間的 commit 訊息進行簡短摘要，AI 產生完摘要後除了會顯示於 terminal 外，也會將摘要內容自動複製到剪貼簿中
+```bash
+commit-assistant summary --start-from "commit 起始日期(YYYY-mm-dd HH:MM:SS 或 YYYY-mm-dd)" --end-to "commit 結束日期(YYYY-mm-dd HH:MM:SS 或 YYYY-mm-dd)"
+```
+
 ## 常見問題
 
 **Q: 如何更新 API 金鑰？**  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.1"
+version = "0.1.2"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.8"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
     "google-generativeai>=0.8.4",
     "questionary>=2.1.0",
     "rich>=13.9.4",
+    "pyperclip>=1.9.0",
 ]
 license = {text = "Apache-2.0"}
 

--- a/src/commit_assistant/cli.py
+++ b/src/commit_assistant/cli.py
@@ -1,6 +1,6 @@
 import click
 
-from commit_assistant.commands import commit, config, install
+from commit_assistant.commands import commit, config, install, summary
 
 
 @click.group()
@@ -15,6 +15,7 @@ def cli(ctx: click.Context) -> None:
 cli.add_command(commit)
 cli.add_command(install)
 cli.add_command(config)
+cli.add_command(summary)
 
 if __name__ == "__main__":
     cli()

--- a/src/commit_assistant/commands/__init__.py
+++ b/src/commit_assistant/commands/__init__.py
@@ -3,5 +3,6 @@
 from .commit import commit
 from .config import config
 from .install import install
+from .summary import summary
 
-__all__ = ["commit", "install", "config"]
+__all__ = ["commit", "install", "config", "summary"]

--- a/src/commit_assistant/commands/summary.py
+++ b/src/commit_assistant/commands/summary.py
@@ -1,34 +1,22 @@
-import click
-import os
-import pyperclip
 import sys
-from datetime import datetime
-from typing import List, Union
+from datetime import datetime, timedelta
+from typing import Optional
 
-import google.generativeai as genai
-import questionary
+import click
+import pyperclip
 from google.generativeai.types import GenerateContentResponse
 
+from commit_assistant.core.base_generator import BaseGeminiAIGenerator
 from commit_assistant.enums.exit_code import ExitCode
-from commit_assistant.utils.console_utils import console, display_ai_message
 from commit_assistant.utils.config_utils import load_config
-from commit_assistant.utils.git_utils import CommitStyleManager, GitCommandRunner
+from commit_assistant.utils.console_utils import console, display_ai_message, loading_spinner
+from commit_assistant.utils.git_utils import GitCommandRunner
 
-class CommitSummaryGenerator:
-    def __init__(self) -> None:
-        api_key = os.getenv("GEMINI_API_KEY")
 
-        if api_key is None:
-            console.print("[yellow]檢測到尚未設定 Gemini api key [/yellow]")
-
-            raise ValueError("請先執行commit-assistant config setup設定API金鑰")
-
-        genai.configure(api_key=api_key)
-        self.model = genai.GenerativeModel(os.getenv("GENERATIVE_MODEL", "gemini-2.0-flash-exp"))
-
-        self.style_manager = CommitStyleManager()
-
-    def generate_commit_summary(self, commit_message: str) -> str:
+class CommitSummaryGenerator(BaseGeminiAIGenerator):
+    def generate_commit_summary(
+        self, commit_message: str, start_dt: datetime, end_dt: datetime
+    ) -> Optional[GenerateContentResponse]:
         """生成 commit message 的摘要
 
         Args:
@@ -37,64 +25,141 @@ class CommitSummaryGenerator:
         Returns:
             str: commit message 摘要
         """
-        console.print(f"[cyan]正在進行 commit 摘要 [/cyan]")
+        start_str = start_dt.strftime("%Y-%m-%d %H:%M:%S")
+        end_str = end_dt.strftime("%Y-%m-%d %H:%M:%S")
+
+        console.print(f"[cyan] 摘要期間 {start_str} ~ {end_str} [/cyan]")
 
         try:
-            prompt = f"""
-                請使用繁體中文根據以下的 commit message 生成 commit 簡短摘要。
-                摘要時請用純文字與換行字元，不要包含任何表情符號或特殊符號。
-                文字中不要包含 commit hash
+            prompt = f"""請根據以下的 commit message 生成繁體中文摘要：
+                1. 使用「•」作為條列符號
+                2. 每個項目需簡短扼要說明修改內容
+                3. 僅包含最重要的前個項目，最多不超過10個項目
+                4. 不使用表情符號或特殊符號
+                5. 不包含 commit hash
 
                 Commit Message:
                 {commit_message}
+
+                輸出格式範例：
+                - 新增用戶註冊功能
+                - 加入電子郵件驗證
+                - 修正登入頁面顯示問題
             """
 
-            response = self.model.generate_content(prompt)
-
-            if not response:
-                console.print("[red]✗[/red] 生成 commit message 失敗")
-                sys.exit(ExitCode.ERROR)
-
-            return response
+            return self._generate_content(prompt)
         except Exception as e:
             console.print("[red]生成commit 摘要時發生錯誤: [/red]")
             console.print(f"[red]{e}[/red]")
             return None
 
+
+def _parse_date(date_str: Optional[str]) -> datetime:
+    """解析日期字串
+
+    Args:
+        date_str (Optional[str]): 使用者輸入的日期字串
+
+    Raises:
+        click.BadParameter: _description_
+
+    Returns:
+        datetime: 解析後的日期
+    """
+
+    if date_str is None:
+        return datetime.now()
+
+    # 針對使用者輸入的特殊日期進行處理
+    # 例如: today, yesterday, 7d
+    if date_str == "today":
+        return datetime.now()
+    elif date_str == "yesterday":
+        return datetime.now() - timedelta(days=1)
+    elif date_str.endswith("d"):
+        try:
+            days = int(date_str[:-1])
+            return datetime.now() - timedelta(days=days)
+        except ValueError:
+            pass
+
+    # 如果不是上述的特殊日期，則進行日期格式解析
+    # 以下是支援的日期格式
+    formats = [
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+        "%Y.%m.%d",
+        "%Y%m%d",
+        "%d-%m-%Y",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y/%m/%d %H:%M:%S",
+    ]
+
+    for fmt in formats:
+        try:
+            return datetime.strptime(date_str, fmt)
+        except ValueError:
+            continue
+
+    raise click.BadParameter(f"Unsupported date format: {date_str}")
+
+
 @click.command()
-@click.option("--start-from", "start_from", help="Please provide the commit messages starting from which date.", default=None)
-@click.option("--end-to", "end_to", help="Please provide the commit messages ending at which date.", default=None)
+@click.option(
+    "--start-from",
+    "start_from",
+    help="Starting date. Supports: 'YYYY-MM-DD', 'today', 'yesterday', '7d (7 days ago)', or flexible formats",
+    default=None,
+)
+@click.option("--end-to", "end_to", help="Ending date. Same format as start-from", default=None)
 @click.option(
     "--repo-path",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
     help="Path to git repository",
     default=".",
 )
-def summary(start_from: str, end_to: str, repo_path: str) -> None:
-    """
-        將 commit 訊息進行摘要
+def summary(start_from: Optional[str], end_to: Optional[str], repo_path: str) -> None:
+    """將 commit 訊息進行摘要
 
-        Args:
-            start_from (str): 起始日期, 預設使用當日 00:00:00
-            end_to (str): 結束日期, 預設使用當日 23:59:59
+    Args:
+        start_from (str): 起始日期, 預設使用當日 00:00:00
+        end_to (str): 結束日期, 預設使用當日 23:59:59
+        repo_path (str): git repository 路徑
     """
     # 載入環境設定
     load_config(repo_path)
-    
-    start_from = start_from or datetime.now().strftime("%Y-%m-%d 00:00:00")
-    end_to = end_to or datetime.now().strftime("%Y-%m-%d 23:59:59")
+
+    start_dt = _parse_date(start_from)
+    end_dt = _parse_date(end_to)
+
+    # 如果使用者沒有指定日期，則預設為當日
+    # 起始日期為 當日的00:00:00, 結束日期為 當日的23:59:59
+    if start_from is None:
+        start_dt = start_dt.replace(hour=0, minute=0, second=0)
+    if end_to is None:
+        end_dt = end_dt.replace(hour=23, minute=59, second=59)
 
     git_command_runner = GitCommandRunner(repo_path)
 
-    # 獲取 commit message
-    commit_message = git_command_runner.get_commit_message(start_from, end_to)
-    
-    # 透過 AI 進行摘要
-    summary_generator = CommitSummaryGenerator()
-    summary = summary_generator.generate_commit_summary(commit_message)
+    # 獲取該段時間內的commit message
+    commit_message = git_command_runner.get_commits_in_date_range(start_dt, end_dt)
+    if not commit_message:
+        console.print(f"[yellow]{start_dt} ~ {end_dt} 範圍內沒有找到符合條件的 commit message[/yellow]")
+        sys.exit(ExitCode.CANCEL)
+
+    with loading_spinner("正在產生commit 摘要"):
+        # 透過 AI 進行摘要
+        summary_generator = CommitSummaryGenerator()
+        summary = summary_generator.generate_commit_summary(commit_message, start_dt, end_dt)
+
+    if summary is None:
+        console.print("[red]✗[/red] 摘要生成失敗")
+        sys.exit(ExitCode.ERROR)
 
     display_ai_message(summary.text)
 
     # 將摘要複製到剪貼簿
     pyperclip.copy(summary.text)
-    console.log("[green]✓[/green] 摘要已複製到剪貼簿")
+    console.print("[green]✓[/green] 摘要已複製到剪貼簿")
+
+    sys.exit(ExitCode.SUCCESS)

--- a/src/commit_assistant/commands/summary.py
+++ b/src/commit_assistant/commands/summary.py
@@ -1,0 +1,100 @@
+import click
+import os
+import pyperclip
+import sys
+from datetime import datetime
+from typing import List, Union
+
+import google.generativeai as genai
+import questionary
+from google.generativeai.types import GenerateContentResponse
+
+from commit_assistant.enums.exit_code import ExitCode
+from commit_assistant.utils.console_utils import console, display_ai_message
+from commit_assistant.utils.config_utils import load_config
+from commit_assistant.utils.git_utils import CommitStyleManager, GitCommandRunner
+
+class CommitSummaryGenerator:
+    def __init__(self) -> None:
+        api_key = os.getenv("GEMINI_API_KEY")
+
+        if api_key is None:
+            console.print("[yellow]檢測到尚未設定 Gemini api key [/yellow]")
+
+            raise ValueError("請先執行commit-assistant config setup設定API金鑰")
+
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(os.getenv("GENERATIVE_MODEL", "gemini-2.0-flash-exp"))
+
+        self.style_manager = CommitStyleManager()
+
+    def generate_commit_summary(self, commit_message: str) -> str:
+        """生成 commit message 的摘要
+
+        Args:
+            commit_message (str): commit message 內容
+
+        Returns:
+            str: commit message 摘要
+        """
+        console.print(f"[cyan]正在進行 commit 摘要 [/cyan]")
+
+        try:
+            prompt = f"""
+                請使用繁體中文根據以下的 commit message 生成 commit 簡短摘要。
+                摘要時請用純文字與換行字元，不要包含任何表情符號或特殊符號。
+                文字中不要包含 commit hash
+
+                Commit Message:
+                {commit_message}
+            """
+
+            response = self.model.generate_content(prompt)
+
+            if not response:
+                console.print("[red]✗[/red] 生成 commit message 失敗")
+                sys.exit(ExitCode.ERROR)
+
+            return response
+        except Exception as e:
+            console.print("[red]生成commit 摘要時發生錯誤: [/red]")
+            console.print(f"[red]{e}[/red]")
+            return None
+
+@click.command()
+@click.option("--start-from", "start_from", help="Please provide the commit messages starting from which date.", default=None)
+@click.option("--end-to", "end_to", help="Please provide the commit messages ending at which date.", default=None)
+@click.option(
+    "--repo-path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Path to git repository",
+    default=".",
+)
+def summary(start_from: str, end_to: str, repo_path: str) -> None:
+    """
+        將 commit 訊息進行摘要
+
+        Args:
+            start_from (str): 起始日期, 預設使用當日 00:00:00
+            end_to (str): 結束日期, 預設使用當日 23:59:59
+    """
+    # 載入環境設定
+    load_config(repo_path)
+    
+    start_from = start_from or datetime.now().strftime("%Y-%m-%d 00:00:00")
+    end_to = end_to or datetime.now().strftime("%Y-%m-%d 23:59:59")
+
+    git_command_runner = GitCommandRunner(repo_path)
+
+    # 獲取 commit message
+    commit_message = git_command_runner.get_commit_message(start_from, end_to)
+    
+    # 透過 AI 進行摘要
+    summary_generator = CommitSummaryGenerator()
+    summary = summary_generator.generate_commit_summary(commit_message)
+
+    display_ai_message(summary.text)
+
+    # 將摘要複製到剪貼簿
+    pyperclip.copy(summary.text)
+    console.log("[green]✓[/green] 摘要已複製到剪貼簿")

--- a/src/commit_assistant/core/__init__.py
+++ b/src/commit_assistant/core/__init__.py
@@ -1,0 +1,3 @@
+from .base_generator import BaseGeminiAIGenerator
+
+__all__ = ["BaseGeminiAIGenerator"]

--- a/src/commit_assistant/core/base_generator.py
+++ b/src/commit_assistant/core/base_generator.py
@@ -1,0 +1,31 @@
+import os
+from typing import Optional
+
+import google.generativeai as genai
+from google.generativeai.types import GenerateContentResponse
+
+from commit_assistant.utils.console_utils import console
+from commit_assistant.utils.git_utils import CommitStyleManager
+
+
+class BaseGeminiAIGenerator:
+    """建立一個Gemini Ai Generator的基類"""
+
+    def __init__(self) -> None:
+        api_key = os.getenv("GEMINI_API_KEY")
+        if api_key is None:
+            console.print("[yellow]檢測到尚未設定 Gemini api key [/yellow]")
+            raise ValueError("請先執行commit-assistant config setup設定API金鑰")
+
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(os.getenv("GENERATIVE_MODEL", "gemini-2.0-flash-exp"))
+        self.style_manager = CommitStyleManager()
+
+    def _generate_content(self, prompt: str) -> Optional[GenerateContentResponse]:
+        try:
+            response = self.model.generate_content(prompt)
+            return response
+        except Exception as e:
+            console.print("[red]生成內容時發生錯誤: [/red]")
+            console.print(f"[red]{e}[/red]")
+            return None

--- a/src/commit_assistant/prompts/.gitignore
+++ b/src/commit_assistant/prompts/.gitignore
@@ -1,0 +1,2 @@
+custom/
+custom/*

--- a/src/commit_assistant/utils/git_utils.py
+++ b/src/commit_assistant/utils/git_utils.py
@@ -2,6 +2,7 @@ import locale
 import os
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -38,11 +39,21 @@ class GitCommandRunner:
         result = self.run_git_command(cmd)
         return result
 
-    def get_commit_message(self, start_from: str, end_to: str) -> str:
-        """獲取指定日期範圍內的commit message"""
-        cmd = ["git", "log", f"--since={start_from}", f"--until={end_to}"]
-        result = self.run_git_command(cmd)
-        return result
+    def get_commits_in_date_range(self, start_dt: datetime, end_dt: datetime) -> str:
+        """獲取指定日期範圍內的commit message
+
+        Args:
+            start_dt: 起始時間
+            end_dt: 結束時間
+
+        Returns:
+            str: commits 的完整內容
+        """
+        start_str = start_dt.strftime("%Y-%m-%d %H:%M:%S")
+        end_str = end_dt.strftime("%Y-%m-%d %H:%M:%S")
+
+        cmd = ["git", "log", f"--since={start_str}", f"--until={end_str}"]
+        return self.run_git_command(cmd)
 
     def run_git_command(self, cmd: List[str]) -> str:
         """執行git命令並處理編碼

--- a/src/commit_assistant/utils/git_utils.py
+++ b/src/commit_assistant/utils/git_utils.py
@@ -38,6 +38,12 @@ class GitCommandRunner:
         result = self.run_git_command(cmd)
         return result
 
+    def get_commit_message(self, start_from: str, end_to: str) -> str:
+        """獲取指定日期範圍內的commit message"""
+        cmd = ["git", "log", f"--since={start_from}", f"--until={end_to}"]
+        result = self.run_git_command(cmd)
+        return result
+
     def run_git_command(self, cmd: List[str]) -> str:
         """執行git命令並處理編碼
 


### PR DESCRIPTION
因為我習慣從 commit 去撰寫周報，使用這個功能後， 周報內容可能會變得非常長，因此增加這個功能用於將 commit 內容作簡短摘要。

新功能:
- 新增 `commit-assistant summary` 指令，可針對指定日期區間的 commit 訊息產生摘要。
- 摘要產生後會顯示於 terminal，並自動複製到剪貼簿。
- 增加 pyperclip 套件作為複製到剪貼簿的依賴。

其他:
- 更新 README.md，加入摘要功能的使用說明。
- 在 commands/__init__.py 中加入 summary。
- 建立 src/commit_assistant/commands/summary.py 檔案，包含摘要功能實作。
- 建立 src/commit_assistant/prompts/.gitignore 檔案。