### PR TITLE
feat(commit summary): 增加作者篩選功能

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.2"
+version = "0.1.3"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.8"
 dependencies = [

--- a/src/commit_assistant/commands/summary.py
+++ b/src/commit_assistant/commands/summary.py
@@ -113,17 +113,26 @@ def _parse_date(date_str: Optional[str]) -> datetime:
 )
 @click.option("--end-to", "end_to", help="Ending date. Same format as start-from", default=None)
 @click.option(
+    "--author",
+    "author",
+    help="""Filters commit history to show only commits where the author's name matches the specified regular expression.
+For example: `--author="^Alice"` will match commits authored by names starting with "Alice".
+""",
+    default=None,
+)
+@click.option(
     "--repo-path",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
     help="Path to git repository",
     default=".",
 )
-def summary(start_from: Optional[str], end_to: Optional[str], repo_path: str) -> None:
+def summary(start_from: Optional[str], end_to: Optional[str], author: Optional[str], repo_path: str) -> None:
     """將 commit 訊息進行摘要
 
     Args:
         start_from (str): 起始日期, 預設使用當日 00:00:00
         end_to (str): 結束日期, 預設使用當日 23:59:59
+        author (str): 作者名稱, 預設為 None(不篩選作者)
         repo_path (str): git repository 路徑
     """
     # 載入環境設定
@@ -142,7 +151,7 @@ def summary(start_from: Optional[str], end_to: Optional[str], repo_path: str) ->
     git_command_runner = GitCommandRunner(repo_path)
 
     # 獲取該段時間內的commit message
-    commit_message = git_command_runner.get_commits_in_date_range(start_dt, end_dt)
+    commit_message = git_command_runner.get_commits_in_date_range(start_dt, end_dt, author)
     if not commit_message:
         console.print(f"[yellow]{start_dt} ~ {end_dt} 範圍內沒有找到符合條件的 commit message[/yellow]")
         sys.exit(ExitCode.CANCEL)

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.2"
+    VERSION: str = "0.1.3"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.8"
     LICENSE: str = "Apache-2.0"

--- a/src/commit_assistant/utils/git_utils.py
+++ b/src/commit_assistant/utils/git_utils.py
@@ -39,12 +39,13 @@ class GitCommandRunner:
         result = self.run_git_command(cmd)
         return result
 
-    def get_commits_in_date_range(self, start_dt: datetime, end_dt: datetime) -> str:
+    def get_commits_in_date_range(self, start_dt: datetime, end_dt: datetime, author: str) -> str:
         """獲取指定日期範圍內的commit message
 
         Args:
             start_dt: 起始時間
             end_dt: 結束時間
+            author: 作者名稱
 
         Returns:
             str: commits 的完整內容
@@ -53,6 +54,10 @@ class GitCommandRunner:
         end_str = end_dt.strftime("%Y-%m-%d %H:%M:%S")
 
         cmd = ["git", "log", f"--since={start_str}", f"--until={end_str}"]
+
+        if author:
+            cmd.extend(["--author", author])
+
         return self.run_git_command(cmd)
 
     def run_git_command(self, cmd: List[str]) -> str:

--- a/src/commit_assistant/utils/hook_manager.py
+++ b/src/commit_assistant/utils/hook_manager.py
@@ -79,7 +79,7 @@ class HookManager:
             new_hook_content = additional_content + new_hook_content
             return new_hook_content
 
-        current_content = self.hook_path.read_text()
+        current_content = self.hook_path.read_text(encoding="utf-8")
 
         # 如果已經包含我們的命令，則不需要重複添加
         if "commit-assistant" in current_content:


### PR DESCRIPTION
新功能:
- 允許使用者透過 `--author` 選項，使用正則表達式篩選特定作者的 commit 紀錄。
- 更新 `summary` 指令，將 `author` 參數傳遞給 `GitCommandRunner.get_commits_in_date_range` 函數。
- 更新 `GitCommandRunner.get_commits_in_date_range` 函數，若指定 `author` 則將 `--author` 參數加入 git log 指令。
- 在 `--author` 的 help message 裡添加了使用範例，使其更易於理解。