### PR TITLE
feat(cli): 新增版本更新檢查與升級功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 # custom
 .ruff_cache/
 src/**/resources/installations.toml
+src/**/resources/latest_upgrade_check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.6"
+version = "0.1.7"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.9"
 dependencies = [
@@ -58,6 +58,8 @@ dependencies = [
     "tomli>=2.2.1",
     "tomli-w>=1.2.0",
     "PyYAML>=6.0.2",
+    "requests>=2.32.3",
+    "packaging>=24.2",
 ]
 
 [project.optional-dependencies]
@@ -66,6 +68,8 @@ dev = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "types-PyYAML>=6.0.12.20241230",
+    "types-requests>=2.32.0.20241016",
+    "freezegun>=1.5.1",
 ]
 
 [project.license]

--- a/src/commit_assistant/cli.py
+++ b/src/commit_assistant/cli.py
@@ -1,13 +1,22 @@
 import click
 
-from commit_assistant.commands import commit, config, install, style, summary, update
+from commit_assistant.commands import commit, config, install, style, summary, update, upgrade
 from commit_assistant.core.project_config import ProjectInfo
+from commit_assistant.utils.upgrade_checker import UpgradeChecker
 
 
 @click.group()
 @click.version_option(version=ProjectInfo.VERSION, prog_name=ProjectInfo.NAME)
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """Commit Assistant CLI 工具"""
+    # 取得當前執行的命令
+    cmd_name = ctx.invoked_subcommand
+
+    # 當upgrade以外的命令執行時，檢查更新
+    if cmd_name != "upgrade":
+        upgrade_checker = UpgradeChecker()
+        upgrade_checker.run_version_check()
 
 
 # 註冊子命令
@@ -17,6 +26,7 @@ cli.add_command(config)
 cli.add_command(style)
 cli.add_command(summary)
 cli.add_command(update)
+cli.add_command(upgrade)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/commit_assistant/commands/__init__.py
+++ b/src/commit_assistant/commands/__init__.py
@@ -6,5 +6,6 @@ from .install import install
 from .style import style
 from .summary import summary
 from .update import update
+from .upgrade import upgrade
 
-__all__ = ["commit", "install", "config", "summary", "update", "style"]
+__all__ = ["commit", "install", "config", "summary", "update", "style", "upgrade"]

--- a/src/commit_assistant/commands/commit.py
+++ b/src/commit_assistant/commands/commit.py
@@ -10,9 +10,9 @@ from commit_assistant.core.base_generator import BaseGeminiAIGenerator
 from commit_assistant.enums.commit_style import CommitStyle
 from commit_assistant.enums.exit_code import ExitCode
 from commit_assistant.enums.user_choices import UserChoices
+from commit_assistant.utils.command_runners import GitCommandRunner
 from commit_assistant.utils.config_utils import load_config
 from commit_assistant.utils.console_utils import console, display_ai_message, loading_spinner
-from commit_assistant.utils.git_utils import GitCommandRunner
 
 
 class EnhancedCommitGenerator(BaseGeminiAIGenerator):
@@ -154,7 +154,6 @@ def update_commit_message(commit_msg_file: str, ai_message: str) -> int:
         return ExitCode.ERROR.value
 
 
-# @click.pass_context
 @click.command()
 @click.option(
     "--msg-file", "commit_msg_file", type=click.Path(), help="Path to commit message file", required=True

--- a/src/commit_assistant/commands/summary.py
+++ b/src/commit_assistant/commands/summary.py
@@ -8,9 +8,9 @@ from google.generativeai.types import GenerateContentResponse
 
 from commit_assistant.core.base_generator import BaseGeminiAIGenerator
 from commit_assistant.enums.exit_code import ExitCode
+from commit_assistant.utils.command_runners import GitCommandRunner
 from commit_assistant.utils.config_utils import load_config
 from commit_assistant.utils.console_utils import console, display_ai_message, loading_spinner
-from commit_assistant.utils.git_utils import GitCommandRunner
 
 
 class CommitSummaryGenerator(BaseGeminiAIGenerator):

--- a/src/commit_assistant/commands/upgrade.py
+++ b/src/commit_assistant/commands/upgrade.py
@@ -1,0 +1,66 @@
+import click
+
+from commit_assistant.core.project_config import ProjectInfo
+from commit_assistant.utils.command_runners import CommandRunner
+from commit_assistant.utils.console_utils import console
+from commit_assistant.utils.upgrade_checker import UpgradeChecker
+
+
+def _upgrade(yes: bool) -> None:
+    """更新 commit assistant 至最新版本"""
+    # 先檢查是否真的需要更新
+    checker = UpgradeChecker()
+
+    newest_version = checker.check_for_updates_version()
+
+    if not newest_version:
+        console.print(f"[green]目前已是最新版本。當前版本: [cyan]{ProjectInfo.VERSION}[/cyan][/green]")
+        return
+
+    # 確認是否要更新
+    if not yes:
+        console.print(f"發現新版本: [cyan]{newest_version}[/cyan]")
+        confirm = click.confirm("是否要更新？", default=True)
+
+        if not confirm:
+            console.print("[yellow]已取消更新[/yellow]")
+            return
+
+    # 更新
+    console.print(f"[bold cyan]正在更新至 {newest_version}...[/bold cyan]")
+
+    try:
+        runner = CommandRunner()
+
+        cmd = ["pip", "install", ProjectInfo.GITHUB_REPO_URL, "-U"]
+        runner.run_command(cmd)
+
+        console.print("[green bold]✓ 更新成功[/green bold]")
+        console.print(
+            f"[green]已從 [cyan]{ProjectInfo.VERSION}[/cyan] 更新至 [cyan]{newest_version}[/cyan][/green]"
+        )
+    except Exception as e:
+        console.print(f"[bold red]× 更新過程中發生錯誤: {str(e)}[/bold red]")
+
+
+@click.group(invoke_without_command=True)
+@click.option("--yes", "-y", is_flag=True, help="auto confirm")
+@click.pass_context
+def upgrade(ctx: click.Context, yes: bool = False) -> None:
+    """更新 commit assistant 至最新版本"""
+    # 如果沒有其他子命令，則執行更新
+    if ctx.invoked_subcommand is None:
+        _upgrade(yes)
+
+
+@upgrade.command()
+def check() -> None:
+    """檢查更新"""
+    checker = UpgradeChecker()
+
+    newest_version = checker.check_for_updates_version()
+
+    if newest_version:
+        checker.print_update_message(newest_version)
+    else:
+        console.print(f"[green]目前已是最新版本。當前版本: [cyan]{ProjectInfo.VERSION}[/cyan][/green]")

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.6"
+    VERSION: str = "0.1.7"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.9"
     LICENSE: str = "Apache-2.0"
@@ -35,6 +35,8 @@ class ProjectInfo:
         TOMLI = "tomli>=2.2.1"
         TOMLW = "tomli-w>=1.2.0"
         YAML = "PyYAML>=6.0.2"
+        REQUEST = "requests>=2.32.3"
+        PACKAGING = "packaging>=24.2"
 
     # 專案開發的相依套件
     # 僅有開發時才需要的套件
@@ -43,6 +45,14 @@ class ProjectInfo:
         PYTEST = "pytest>=8.3.4"
         PYTEST_COV = "pytest-cov>=6.0.0"
         YAML_TYPE = "types-PyYAML>=6.0.12.20241230"
+        REQUEST_TYPE = "types-requests>=2.32.0.20241016"
+        FREEZEGUN = "freezegun>=1.5.1"
+
+    # 專案的GitHub Repo URL
+    GITHUB_REPO_URL = "git+https://github.com/OrarioGit/Commit-Assistant.git"
+
+    # 專案GitHub的Release Tag URL
+    RELEASE_TAG_URL = "https://api.github.com/repos/OrarioGit/Commit-Assistant/tags"
 
     # 專案的package路徑
     PACKAGE_PATH = "src"
@@ -81,6 +91,9 @@ class ProjectInfo:
 
     # 用來記錄比如使用者安裝的版本號、repo路徑等資訊
     INSTALLATIONS_FILE = "installations.toml"
+
+    # 用來記錄上次檢查更新的時間檔名
+    UPGRADE_CHECK_FILE = "latest_upgrade_check"
 
     # unit test相關
     TEST_DIRS = ["commit-assistant"]

--- a/src/commit_assistant/utils/__init__.py
+++ b/src/commit_assistant/utils/__init__.py
@@ -1,19 +1,22 @@
 """Commit Assistant 相關的工具模組"""
 
+from .command_runners import CommandRunner, GitCommandRunner
 from .config_utils import install_config, load_config
 from .console_utils import console
-from .git_utils import GitCommandRunner
 from .hook_manager import HookManager
 from .style_utils import CommitStyleManager, StyleImporter
 from .update_utils import UpdateManager
+from .upgrade_checker import UpgradeChecker
 
 __all__ = [
     "console",
     "CommitStyleManager",
+    "CommandRunner",
     "GitCommandRunner",
     "load_config",
     "install_config",
     "HookManager",
     "UpdateManager",
     "StyleImporter",
+    "UpgradeChecker",
 ]

--- a/src/commit_assistant/utils/upgrade_checker.py
+++ b/src/commit_assistant/utils/upgrade_checker.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+from typing import Optional
+
+import requests
+from packaging import version
+
+from commit_assistant.core.paths import ProjectPaths
+from commit_assistant.core.project_config import ProjectInfo
+from commit_assistant.utils.console_utils import console, loading_spinner
+
+
+class UpgradeChecker:
+    UNTAGGED_VERSION = "v0.0.0"
+    CHECK_INTERVAL = 60 * 60 * 24  # 1天 每次檢查的時間間隔
+
+    def get_latest_check_time(self) -> Optional[datetime]:
+        """取得上次檢查更新的時間"""
+        latest_check_file = ProjectPaths.RESOURCES_DIR / ProjectInfo.UPGRADE_CHECK_FILE
+
+        if not latest_check_file.exists():
+            return None
+
+        try:
+            with open(latest_check_file, "r", encoding="utf-8") as f:
+                return datetime.fromisoformat(f.read())
+        except Exception:
+            return None
+
+    def should_check_update(self) -> bool:
+        """檢查是否要檢查更新"""
+        last_check_time = self.get_latest_check_time()
+
+        # 完全沒有檢查過，需要更新
+        if last_check_time is None:
+            return True
+
+        # 距離上次檢查的時間超過 CHECK_INTERVAL，需要更新
+        return (datetime.now() - last_check_time).total_seconds() > self.CHECK_INTERVAL
+
+    def save_latest_check_time(self) -> None:
+        """儲存最新的檢查時間"""
+        latest_check_file = ProjectPaths.RESOURCES_DIR / ProjectInfo.UPGRADE_CHECK_FILE
+
+        with open(latest_check_file, "w", encoding="utf-8") as f:
+            f.write(datetime.now().isoformat())
+
+    def check_for_updates_version(self) -> Optional[str]:
+        """檢查是否有新版本
+
+        Returns:
+            Optional[str]: 如果有新版本，回傳新版本號；否則回傳 None
+        """
+        try:
+            with loading_spinner("檢查更新中..."):
+                # 獲取最新的版本號
+                response = requests.get(ProjectInfo.RELEASE_TAG_URL)
+                tags = [tag["name"] for tag in response.json()]
+
+            # 按版本排序
+            sorted_tags = sorted(tags, key=lambda x: version.parse(x.lstrip("v")), reverse=True)
+
+            latest_tag = sorted_tags[0] if sorted_tags else self.UNTAGGED_VERSION
+            current = version.parse(ProjectInfo.VERSION.lstrip("v"))
+
+            # 如果有新版本，回傳新版本號
+            if version.parse(latest_tag.lstrip("v")) > current:
+                return latest_tag
+
+            return None
+
+        except Exception:
+            console.print("[red]檢查更新失敗，請稍後再試")
+            return None
+
+    def print_update_message(self, newest_version: str) -> None:
+        """印出更新訊息
+
+        Args:
+            newest_version (str): 最新版本號
+        """
+        console.print(
+            f"[yellow]發現新版本 [cyan]{newest_version}[/cyan]！您可以透過以下方式更新：[/yellow]\n"
+        )
+        console.print("[yellow]1. 執行更新指令[/yellow]")
+        console.print(f"   [green]{ProjectInfo.CLI_MAIN_COMMAND} upgrade[/green]")
+        console.print("[yellow]2. 透過 pip 安裝最新版本[/yellow]")
+        console.print(f"   [green]pip install {ProjectInfo.GITHUB_REPO_URL} -U[/green]\n")
+
+    def run_version_check(self, force: bool = False) -> None:
+        """執行版本檢查
+
+        Args:
+            force (bool, optional): 是否強制檢查更新. Defaults to False.
+        """
+        if not force and not self.should_check_update():
+            return
+
+        newest_version = self.check_for_updates_version()
+
+        if newest_version:
+            self.print_update_message(newest_version)
+
+        self.save_latest_check_time()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,24 @@
+import sys
+from unittest.mock import MagicMock, patch
+
 from click.testing import CliRunner
 
 from commit_assistant.cli import cli
+from commit_assistant.core.project_config import ProjectInfo
+
+cli_module = sys.modules["commit_assistant.cli"]
+
+
+def test_cli_version() -> None:
+    """測試顯示版本資訊"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+
+    # 檢查是否有成功執行
+    assert result.exit_code == 0
+    # 檢查是否顯示了正確的版本資訊
+    assert ProjectInfo.VERSION in result.output
+    assert ProjectInfo.NAME in result.output
 
 
 def test_cli_help() -> None:
@@ -28,3 +46,32 @@ def test_cli_without_command() -> None:
     # 應該顯示幫助訊息而不是錯誤
     assert result.exit_code == 0
     assert "Commit Assistant CLI 工具" in result.output
+
+
+@patch.object(cli_module, "UpgradeChecker")
+def test_upgrade_check_on_commands(mock_upgrade_checker: MagicMock) -> None:
+    """測試非upgrade命令會觸發版本檢查"""
+    mock_checker_instance = MagicMock()
+    mock_upgrade_checker.return_value = mock_checker_instance
+
+    runner = CliRunner()
+    # 測試隨便一個非upgrade的命令
+    runner.invoke(cli, ["commit", "--help"])
+
+    # 驗證UpgradeChecker被初始化並執行了檢查
+    mock_upgrade_checker.assert_called_once()
+    mock_checker_instance.run_version_check.assert_called_once()
+
+
+@patch.object(cli_module, "UpgradeChecker")
+def test_upgrade_check_on_upgrade_command(mock_upgrade_checker: MagicMock) -> None:
+    """測試upgrade命令不會觸發版本檢查"""
+    mock_checker_instance = MagicMock()
+    mock_upgrade_checker.return_value = mock_checker_instance
+
+    runner = CliRunner()
+    # 測試upgrade命令
+    runner.invoke(cli, ["upgrade", "--help"])
+
+    # 驗證UpgradeChecker沒有執行檢查
+    mock_upgrade_checker.assert_not_called()

--- a/tests/test_upgrade_checker.py
+++ b/tests/test_upgrade_checker.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from freezegun import freeze_time
+
+from commit_assistant.core.paths import ProjectPaths
+from commit_assistant.core.project_config import ProjectInfo
+from commit_assistant.utils.upgrade_checker import UpgradeChecker
+
+
+@pytest.fixture
+def upgrade_checker() -> UpgradeChecker:
+    """建立UpgradeChecker實例"""
+    return UpgradeChecker()
+
+
+@pytest.fixture
+def upgrade_check_file(tmp_path: Path) -> Path:
+    """建立測試用的檢查更新時間紀錄檔案"""
+    file_path = ProjectPaths.RESOURCES_DIR / ProjectInfo.UPGRADE_CHECK_FILE
+    file_path.touch()
+    return file_path
+
+
+def test_get_latest_check_time_file_not_exists(upgrade_checker: UpgradeChecker) -> None:
+    """測試檢查更新時，上次檢測時間紀錄檔案不存在的情況"""
+    with patch("pathlib.Path.exists", return_value=False):
+        result = upgrade_checker.get_latest_check_time()
+        assert result is None
+
+
+def test_get_latest_check_time_valid_data(upgrade_checker: UpgradeChecker) -> None:
+    """測試檢查更新時，上次檢測時間紀錄檔案存在且有有效資料的情況"""
+    test_time = datetime.now()
+    with patch("pathlib.Path.exists", return_value=True):
+        with patch("builtins.open", mock_open(read_data=test_time.isoformat())):
+            result = upgrade_checker.get_latest_check_time()
+            assert result == test_time
+
+
+def test_get_latest_check_time_invalid_data(upgrade_checker: UpgradeChecker) -> None:
+    """測試檢查更新時，上次檢測時間紀錄檔案存在但讀取資料錯誤的情況"""
+    with patch("pathlib.Path.exists", return_value=True):
+        with patch("builtins.open", mock_open(read_data="invalid_date")):
+            result = upgrade_checker.get_latest_check_time()
+            assert result is None
+
+
+def test_should_check_update_no_previous_check(upgrade_checker: UpgradeChecker) -> None:
+    """測試從未檢查過更新的情況"""
+    with patch.object(UpgradeChecker, "get_latest_check_time", return_value=None):
+        assert upgrade_checker.should_check_update() is True
+
+
+def test_should_check_update_recent_check(upgrade_checker: UpgradeChecker) -> None:
+    """測試最近檢查過更新的情況"""
+    recent_time = datetime.now() - timedelta(seconds=UpgradeChecker.CHECK_INTERVAL - 100)
+    with patch.object(UpgradeChecker, "get_latest_check_time", return_value=recent_time):
+        # 上次檢測時間距離現在不到 CHECK_INTERVAL，不需要檢查
+        assert upgrade_checker.should_check_update() is False
+
+
+def test_should_check_update_old_check(upgrade_checker: UpgradeChecker) -> None:
+    """測試很久以前檢查過更新的情況"""
+    old_time = datetime.now() - timedelta(seconds=UpgradeChecker.CHECK_INTERVAL + 100)
+    with patch.object(UpgradeChecker, "get_latest_check_time", return_value=old_time):
+        # 超過 CHECK_INTERVAL，需要檢查
+        assert upgrade_checker.should_check_update() is True
+
+
+@freeze_time("2025-01-01 12:00:00")
+def test_save_latest_check_time(upgrade_checker: UpgradeChecker, upgrade_check_file: Path) -> None:
+    """測試保存最新的檢查時間"""
+    mock_file = mock_open()
+    with patch("builtins.open", mock_file):
+        upgrade_checker.save_latest_check_time()
+
+        mock_file.assert_called_once_with(upgrade_check_file, "w", encoding="utf-8")
+        mock_file().write.assert_called_once_with("2025-01-01T12:00:00")
+
+
+@pytest.mark.parametrize(
+    "current_version,latest_tag,expected_result",
+    [
+        ("v1.0.0", "v1.1.0", "v1.1.0"),  # 新版本檢查
+        ("v1.1.0", "v1.0.0", None),  # 當前版本比最新版本新
+        ("v1.0.0", "v1.0.0", None),  # 當前版本已經是最新了
+    ],
+)
+def test_check_for_updates_version(
+    current_version: str, latest_tag: str, expected_result: Optional[str], upgrade_checker: UpgradeChecker
+) -> None:
+    """測試檢查是否有新版本"""
+    mock_response = MagicMock()
+    mock_response.json.return_value = [{"name": latest_tag}]
+
+    # mock 發請請求的函數
+    with patch("requests.get", return_value=mock_response):
+        with patch.object(ProjectInfo, "VERSION", current_version):
+            result = upgrade_checker.check_for_updates_version()
+            assert result == expected_result
+
+
+def test_check_for_updates_version_exception(upgrade_checker: UpgradeChecker) -> None:
+    """測試檢查是否有新版本時發生錯誤"""
+    with patch("requests.get", side_effect=Exception):
+        result = upgrade_checker.check_for_updates_version()
+        assert result is None
+
+
+def test_print_update_message(upgrade_checker: UpgradeChecker, capsys: pytest.CaptureFixture) -> None:
+    """測試印出更新提示訊息"""
+    upgrade_checker.print_update_message("v2.0.0")
+
+    captured = capsys.readouterr()
+    assert "發現新版本 v2.0.0！您可以透過以下方式更新：" in captured.out
+    assert "執行更新指令" in captured.out
+    assert "commit-assistant upgrade" in captured.out
+    assert "透過 pip 安裝最新版本" in captured.out
+
+
+def test_run_version_check_no_update_needed(upgrade_checker: UpgradeChecker) -> None:
+    """測試不需要檢查更新的情況"""
+    with patch.object(UpgradeChecker, "should_check_update", return_value=False):
+        with patch.object(UpgradeChecker, "check_for_updates_version") as mock_check:
+            with patch.object(UpgradeChecker, "save_latest_check_time") as mock_save:
+                upgrade_checker.run_version_check(force=False)
+                mock_check.assert_not_called()
+                mock_save.assert_not_called()
+
+
+def test_run_version_check_force_update(upgrade_checker: UpgradeChecker) -> None:
+    """測試強制檢查更新的情況"""
+    with patch.object(UpgradeChecker, "should_check_update", return_value=False):
+        with patch.object(UpgradeChecker, "check_for_updates_version", return_value=None) as mock_check:
+            with patch.object(UpgradeChecker, "save_latest_check_time") as mock_save:
+                upgrade_checker.run_version_check(force=True)
+                mock_check.assert_called_once()
+                mock_save.assert_called_once()
+
+
+def test_run_version_check_new_version_available(upgrade_checker: UpgradeChecker) -> None:
+    """測試有新版本可用的情況"""
+    with patch.object(UpgradeChecker, "should_check_update", return_value=True):
+        with patch.object(UpgradeChecker, "check_for_updates_version", return_value="v2.0.0"):
+            with patch.object(UpgradeChecker, "print_update_message") as mock_print:
+                with patch.object(UpgradeChecker, "save_latest_check_time") as mock_save:
+                    upgrade_checker.run_version_check()
+                    mock_print.assert_called_once_with("v2.0.0")
+                    mock_save.assert_called_once()
+
+
+def test_run_version_check_no_new_version(upgrade_checker: UpgradeChecker) -> None:
+    """測試沒有新版本可用的情況"""
+    with patch.object(UpgradeChecker, "should_check_update", return_value=True):
+        with patch.object(UpgradeChecker, "check_for_updates_version", return_value=None):
+            with patch.object(UpgradeChecker, "print_update_message") as mock_print:
+                with patch.object(UpgradeChecker, "save_latest_check_time") as mock_save:
+                    upgrade_checker.run_version_check()
+                    mock_print.assert_not_called()
+                    mock_save.assert_called_once()

--- a/tests/test_upgrade_command.py
+++ b/tests/test_upgrade_command.py
@@ -1,0 +1,212 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from commit_assistant.commands.upgrade import _upgrade, check, upgrade
+
+upgrade_module = sys.modules["commit_assistant.commands.upgrade"]
+
+
+@pytest.fixture
+def mock_version_data() -> dict[str, str]:
+    new_version = "v1.0.0"
+    current_version = "v0.0.0"
+    return {"new_version": new_version, "current_version": current_version}
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+def test_check_has_update(mock_checker_class: MagicMock, mock_version_data: dict) -> None:
+    """測試檢查是否有新版本"""
+    # Setup mock
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = mock_version_data.get("new_version")
+    mock_checker_class.return_value = mock_checker
+
+    runner = CliRunner()
+    result = runner.invoke(check)
+
+    # 驗證結果
+    assert result.exit_code == 0
+    mock_checker.check_for_updates_version.assert_called_once()
+    # 驗證是否有正確印出更新訊息
+    mock_checker.print_update_message.assert_called_once_with(mock_version_data.get("new_version"))
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+@patch("commit_assistant.core.project_config.ProjectInfo.VERSION", new_callable=lambda: "v1.0.0")
+def test_check_no_update(mock_version: str, mock_checker_class: MagicMock) -> None:
+    """測試當前已經是最新版本"""
+    # Setup mock
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = None
+    mock_checker_class.return_value = mock_checker
+
+    with patch("commit_assistant.utils.console_utils.console.print") as mock_print:
+        runner = CliRunner()
+        result = runner.invoke(check)
+
+        # 驗證結果
+        assert result.exit_code == 0
+        mock_checker.check_for_updates_version.assert_called_once()
+        mock_checker.print_update_message.assert_not_called()
+        mock_print.assert_called_once()
+        assert "目前已是最新版本" in mock_print.call_args[0][0]
+        assert mock_version in mock_print.call_args[0][0]
+
+
+@patch.object(upgrade_module, "_upgrade")
+def test_upgrade_command_no_subcommand(mock_upgrade: MagicMock) -> None:
+    """測試執行 upgrade 指令"""
+    runner = CliRunner()
+    result = runner.invoke(upgrade)
+
+    # 驗證結果
+    assert result.exit_code == 0
+    mock_upgrade.assert_called_once_with(False)
+
+
+@patch.object(upgrade_module, "upgrade")
+def test_upgrade_with_subcommand(mock_upgrade: MagicMock) -> None:
+    """測試執行 upgrade 指令並帶上子命令"""
+    runner = CliRunner()
+    result = runner.invoke(upgrade, ["check"])
+
+    # 這裡有帶上子命令，所以不應該執行_upgrade函數
+    mock_upgrade.assert_not_called()
+    assert result.exit_code == 0
+
+
+@patch.object(upgrade_module, "_upgrade")
+def test_upgrade_command_with_yes_flag(mock_upgrade: MagicMock) -> None:
+    """測試執行 upgrade 指令並帶上 --yes 參數"""
+    runner = CliRunner()
+    result = runner.invoke(upgrade, ["--yes"])
+
+    # 驗證結果
+    assert result.exit_code == 0
+    mock_upgrade.assert_called_once_with(True)
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+@patch("commit_assistant.core.project_config.ProjectInfo.VERSION", new_callable=lambda: "v1.0.0")
+def test_upgrade_function_no_update_available(mock_version: str, mock_checker_class: MagicMock) -> None:
+    """測試更新指令，但沒有新版本可用"""
+    # Setup mock
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = None
+    mock_checker_class.return_value = mock_checker
+
+    # Run function
+    with patch("commit_assistant.utils.console_utils.console.print") as mock_print:
+        _upgrade(True)
+
+        # Check results
+        mock_checker.check_for_updates_version.assert_called_once()
+        mock_print.assert_called_once()
+        assert "目前已是最新版本" in mock_print.call_args[0][0]
+        assert mock_version in mock_print.call_args[0][0]
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+@patch("click.confirm", return_value=False)
+def test_upgrade_function_user_cancels(
+    mock_confirm: MagicMock, mock_checker_class: MagicMock, mock_version_data: dict
+) -> None:
+    """測試更新指令，但使用者取消更新"""
+    # Setup mock
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = mock_version_data.get("new_version")
+    mock_checker_class.return_value = mock_checker
+
+    with patch("commit_assistant.utils.console_utils.console.print") as mock_print:
+        _upgrade(False)
+
+        # Check results
+        mock_checker.check_for_updates_version.assert_called_once()
+        mock_confirm.assert_called_once()
+        assert mock_print.call_count == 2
+        assert "已取消更新" in mock_print.call_args_list[1][0][0]
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+@patch.object(upgrade_module, "CommandRunner")
+def test_upgrade_function_successful_update(
+    mock_runner_class: MagicMock,
+    mock_checker_class: MagicMock,
+    mock_version_data: dict,
+) -> None:
+    """測試更新指令，並成功更新"""
+    # Setup mocks
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = mock_version_data.get("new_version")
+    mock_checker_class.return_value = mock_checker
+
+    mock_runner = MagicMock()
+    mock_runner_class.return_value = mock_runner
+
+    # 測試--yes參數 = true的情況
+    with patch("commit_assistant.utils.console_utils.console.print") as mock_print:
+        _upgrade(True)
+
+        # Check results
+        mock_checker.check_for_updates_version.assert_called_once()
+        mock_runner.run_command.assert_called_once()
+        assert mock_print.call_count == 3
+        assert "正在更新至" in mock_print.call_args_list[0][0][0]
+        assert "更新成功" in mock_print.call_args_list[1][0][0]
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+@patch.object(upgrade_module, "CommandRunner")
+def test_upgrade_function_update_error(
+    mock_runner_class: MagicMock,
+    mock_checker_class: MagicMock,
+    mock_version_data: dict,
+) -> None:
+    """測試更新指令，但更新過程中發生錯誤"""
+    # Setup mocks
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = mock_version_data.get("new_version")
+    mock_checker_class.return_value = mock_checker
+
+    mock_runner = MagicMock()
+    # 測試發生錯誤的情況
+    mock_runner.run_command.side_effect = Exception("Installation failed")
+    mock_runner_class.return_value = mock_runner
+
+    # 測試--yes參數 = true的情況
+    with patch("commit_assistant.utils.console_utils.console.print") as mock_print:
+        _upgrade(True)
+
+        # Check results
+        mock_checker.check_for_updates_version.assert_called_once()
+        mock_runner.run_command.assert_called_once()
+        assert "更新過程中發生錯誤" in mock_print.call_args[0][0]
+
+
+@patch.object(upgrade_module, "UpgradeChecker")
+@patch("click.confirm", return_value=True)
+@patch.object(upgrade_module, "CommandRunner")
+def test_upgrade_function_manual_confirm(
+    mock_runner_class: MagicMock,
+    mock_confirm: MagicMock,
+    mock_checker_class: MagicMock,
+    mock_version_data: dict,
+) -> None:
+    """測試更新指令，並手動確認更新"""
+    # Setup mocks
+    mock_checker = MagicMock()
+    mock_checker.check_for_updates_version.return_value = mock_version_data.get("new_version")
+    mock_checker_class.return_value = mock_checker
+
+    mock_runner = MagicMock()
+    mock_runner_class.return_value = mock_runner
+
+    # false 代表使用者需要自己確認是否更新
+    _upgrade(False)
+
+    # Check results
+    mock_confirm.assert_called_once()
+    mock_runner.run_command.assert_called_once()


### PR DESCRIPTION
新增 `upgrade` 命令，用於檢查和更新 Commit Assistant 至最新版本。

- 在 CLI 啟動時檢查版本更新，並提示使用者。
- 新增 `upgrade` 命令，允許使用者手動檢查和升級。
- 將 git_utils.py 更名為 command_runners.py，並將 CommandRunner 獨立出來，提供通用的命令執行能力。
- 修正了其他命令執行時也會檢查更新的問題。
- 更新專案版本號至 0.1.7。

本次更新包含重大改進，鼓勵使用者升級。