### PR TITLE
chore(config): 更新版本至 0.1.8 並調整預設提交風格

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.7"
+version = "0.1.8"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.9"
 dependencies = [

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.7"
+    VERSION: str = "0.1.8"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.9"
     LICENSE: str = "Apache-2.0"

--- a/src/commit_assistant/resources/config/.commit-assistant-config
+++ b/src/commit_assistant/resources/config/.commit-assistant-config
@@ -5,4 +5,4 @@ ENABLE_COMMIT_ASSISTANT=true
 USE_MODEL=gemini-2.0-flash-exp
 
 # commit style 1. conventional 2. emoji 3. angular 4. custom
-COMMIT_STYLE=custom
+COMMIT_STYLE=conventional

--- a/src/commit_assistant/utils/config_utils.py
+++ b/src/commit_assistant/utils/config_utils.py
@@ -81,7 +81,12 @@ def install_config(repo_root: str) -> None:
     """
     安裝配置文件到專案根目錄
     """
-    config_file = Path(repo_root) / ProjectInfo.CONFIG_TEMPLATE_NAME
+    save_config_path = Path(repo_root) / ProjectInfo.REPO_ASSISTANT_DIR
+
+    # 確保專案配置文件夾存在
+    save_config_path.mkdir(exist_ok=True)
+
+    config_file = save_config_path / ProjectInfo.CONFIG_TEMPLATE_NAME
 
     if config_file.exists():
         return

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -120,7 +120,7 @@ def test_install_config(tmp_path: Path, mock_project_paths: Path) -> None:
     install_config(str(tmp_path))
 
     # 確認設定檔被複製
-    config_file = tmp_path / ProjectInfo.CONFIG_TEMPLATE_NAME
+    config_file = tmp_path / ProjectInfo.REPO_ASSISTANT_DIR / ProjectInfo.CONFIG_TEMPLATE_NAME
     assert config_file.exists()
     assert "COMMIT_STYLE" in config_file.read_text()
 
@@ -138,8 +138,12 @@ def test_install_config_copy_error(tmp_path: Path, capsys: pytest.CaptureFixture
 
 def test_install_config_existing_file(tmp_path: Path) -> None:
     """測試安裝設定檔到已存在檔案的情況"""
+    # 建立模擬的專案資料夾
+    repo_config_folder = tmp_path / ProjectInfo.REPO_ASSISTANT_DIR
+    repo_config_folder.mkdir()
+
     # 建立已存在的設定檔
-    config_file = tmp_path / ProjectInfo.CONFIG_TEMPLATE_NAME
+    config_file = repo_config_folder / ProjectInfo.CONFIG_TEMPLATE_NAME
     original_content = "COMMIT_STYLE=custom"
     config_file.write_text(original_content)
 


### PR DESCRIPTION
更新專案版本至 0.1.8，並將預設提交風格調整為 conventional。
此外，修正了配置檔案的安裝路徑，確保其放置在專案目錄下的 .commit-assistant 資料夾中。

本次更新包含以下變更：
- 更新 pyproject.toml 和 ProjectInfo 中的版本號。
- 將預設 COMMIT_STYLE 設定為 conventional。
- 修正配置檔案安裝路徑，使用專案目錄下的 .commit-assistant 資料夾。
- 更新相關測試案例。

這些變更旨在提升工具的版本一致性，並改善配置檔案的管理方式，避免污染專案根目錄。

BREAKING CHANGE: 配置檔案的存放位置從專案根目錄變更為專案目錄下的 `.commit-assistant` 資料夾。如果使用者在專案根目錄下有手動修改過的 `.commit-assistant-config` 檔案，需要將其移動到新的位置。