### PR TITLE
feat(core): 更新 google-genai 依賴來修正 429 問題

### DIFF
--- a/.commit-assistant/.commit-assistant-config
+++ b/.commit-assistant/.commit-assistant-config
@@ -2,7 +2,7 @@
 ENABLE_COMMIT_ASSISTANT=true
 
 # 模型類型 1. gemini-2.5-flash 2. gemini-2.5-pro 3. gemini-2.0-flash
-USE_MODEL=gemini-2.5-flash
+USE_MODEL=gemini-2.0-flash
 
 # commit style 1. conventional 2. emoji 3. angular 4. custom
 COMMIT_STYLE=angular

--- a/.github/workflows/CI_test.yml
+++ b/.github/workflows/CI_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          python-version: ['3.9', '3.10', '3.11', '3.12']  # 測試多個 Python 版本
+          python-version: ['3.10', '3.11', '3.12', '3.13']  # 測試多個 Python 版本
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ build-backend = "setuptools.build_meta"
 name = "commit-assistant"
 version = "0.1.10"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.0.0",
     "python-dotenv>=1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.9"
+version = "0.1.10"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.9"
 dependencies = [
     "click>=8.0.0",
     "python-dotenv>=1.0.1",
-    "google-generativeai>=0.8.4",
+    "google-genai>=1.50.0",
     "questionary>=2.1.0",
     "rich>=13.9.4",
     "pyperclip>=1.9.0",

--- a/src/commit_assistant/commands/commit.py
+++ b/src/commit_assistant/commands/commit.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import click
 import questionary
-from google.generativeai.types import GenerateContentResponse
+from google.genai.types import GenerateContentResponse
 
 from commit_assistant.core.base_generator import BaseGeminiAIGenerator
 from commit_assistant.enums.commit_style import CommitStyle
@@ -205,7 +205,7 @@ def commit(commit_msg_file: str, repo_path: str) -> int:
         with loading_spinner("AI 生成 commit message"):
             response = generator.generate_structured_message(changed_files, diff_content)
 
-        if not response:
+        if not response or response.text is None:
             console.print("[red]✗[/red] 生成 commit message 失敗")
             sys.exit(ExitCode.ERROR)
 

--- a/src/commit_assistant/commands/summary.py
+++ b/src/commit_assistant/commands/summary.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import click
 import pyperclip
-from google.generativeai.types import GenerateContentResponse
+from google.genai.types import GenerateContentResponse
 
 from commit_assistant.core.base_generator import BaseGeminiAIGenerator
 from commit_assistant.enums.exit_code import ExitCode
@@ -161,7 +161,7 @@ def summary(start_from: Optional[str], end_to: Optional[str], author: Optional[s
         summary_generator = CommitSummaryGenerator()
         summary = summary_generator.generate_commit_summary(commit_message, start_dt, end_dt)
 
-    if summary is None:
+    if summary is None or summary.text is None:
         console.print("[red]✗[/red] 摘要生成失敗")
         sys.exit(ExitCode.ERROR)
 

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -21,7 +21,7 @@ class ProjectInfo:
     NAME: str = "commit-assistant"
     VERSION: str = "0.1.10"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
-    PYTHON_REQUIRES: str = ">=3.9"
+    PYTHON_REQUIRES: str = ">=3.10"
     LICENSE: str = "Apache-2.0"
 
     # 專案的相依套件

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.9"
+    VERSION: str = "0.1.10"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.9"
     LICENSE: str = "Apache-2.0"
@@ -28,7 +28,7 @@ class ProjectInfo:
     class Dependencies(Enum):
         CLICK = "click>=8.0.0"
         PYTHON_DOTENV = "python-dotenv>=1.0.1"
-        GOOGLE_GENERATIVEAI = "google-generativeai>=0.8.4"
+        GOOGLE_GENAI = "google-genai>=1.50.0"
         QUESTIONARY = "questionary>=2.1.0"
         RICH = "rich>=13.9.4"
         PYPERCLIP = "pyperclip>=1.9.0"

--- a/src/commit_assistant/enums/__init__.py
+++ b/src/commit_assistant/enums/__init__.py
@@ -2,7 +2,8 @@
 
 from .commit_style import CommitStyle, StyleScope
 from .config_key import ConfigKey
+from .default_value import DefaultValue
 from .exit_code import ExitCode
 from .user_choices import UserChoices
 
-__all__ = ["ExitCode", "UserChoices", "ConfigKey", "CommitStyle", "StyleScope"]
+__all__ = ["ExitCode", "UserChoices", "ConfigKey", "CommitStyle", "StyleScope", "DefaultValue"]

--- a/src/commit_assistant/enums/default_value.py
+++ b/src/commit_assistant/enums/default_value.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class DefaultValue(Enum):
+    DEFAULT_MODEL = "gemini-2.0-flash"

--- a/src/commit_assistant/scripts/build_pyproject.py
+++ b/src/commit_assistant/scripts/build_pyproject.py
@@ -6,7 +6,7 @@
 3. 提供命令列介面以便手動更新設定
 
 使用方式：
-    python -m commit_assistant.script.build_pyproject
+    python -m commit_assistant.scripts.build_pyproject
 
 注意：
 - 使用前請先執行 pip install -e . 將專案安裝到本地環境 (建議使用虛擬環境)

--- a/tests/test_base_generator.py
+++ b/tests/test_base_generator.py
@@ -2,7 +2,7 @@ from typing import Generator
 from unittest.mock import Mock, patch
 
 import pytest
-from google.generativeai.types import GenerateContentResponse
+from google.genai.types import GenerateContentResponse
 
 from commit_assistant.core.base_generator import BaseGeminiAIGenerator
 from commit_assistant.enums.default_value import DefaultValue

--- a/tests/test_commit_command.py
+++ b/tests/test_commit_command.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
-from google.generativeai.types import GenerateContentResponse
+from google.genai.types import GenerateContentResponse
 
 from commit_assistant.commands.commit import (
     EnhancedCommitGenerator,

--- a/tests/test_summary_command.py
+++ b/tests/test_summary_command.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import click
 import pytest
 from click.testing import CliRunner
-from google.generativeai.types import GenerateContentResponse
+from google.genai.types import GenerateContentResponse
 
 from commit_assistant.commands.summary import (
     CommitSummaryGenerator,


### PR DESCRIPTION
更新 google-genai 依賴至 1.50.0，避免舊套件出現的 429 無法使用之問題
此更新提升了與 Google Gemini API 的相容性，並改善了錯誤處理。

BREAKING CHANGE: `google-generativeai` 已被 `google-genai` 取代，API 初始化方式有所變更。