### PR TITLE
refactor(config): 修正無法正確使用 use_model 選擇對應的模型之問題

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.10"
+version = "0.1.11"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/commit_assistant/core/base_generator.py
+++ b/src/commit_assistant/core/base_generator.py
@@ -32,6 +32,7 @@ from typing import Optional
 from google import genai
 from google.genai.types import GenerateContentResponse
 
+from commit_assistant.enums.config_key import ConfigKey
 from commit_assistant.enums.default_value import DefaultValue
 from commit_assistant.utils.console_utils import console
 from commit_assistant.utils.style_utils import CommitStyleManager
@@ -47,7 +48,7 @@ class BaseGeminiAIGenerator:
             raise ValueError("請先執行 commit-assistant config setup 設定 API 金鑰")
 
         self.client = genai.Client(api_key=api_key)
-        self.model = os.getenv("GENERATIVE_MODEL", DefaultValue.DEFAULT_MODEL.value)
+        self.model = os.getenv(str(ConfigKey.USE_MODEL.value), DefaultValue.DEFAULT_MODEL.value)
         self.style_manager = CommitStyleManager()
 
     def _generate_content(self, prompt: str) -> Optional[GenerateContentResponse]:

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.10"
+    VERSION: str = "0.1.11"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.10"
     LICENSE: str = "Apache-2.0"

--- a/tests/test_base_generator.py
+++ b/tests/test_base_generator.py
@@ -5,6 +5,7 @@ import pytest
 from google.genai.types import GenerateContentResponse
 
 from commit_assistant.core.base_generator import BaseGeminiAIGenerator
+from commit_assistant.enums.config_key import ConfigKey
 from commit_assistant.enums.default_value import DefaultValue
 from commit_assistant.utils.style_utils import CommitStyleManager
 
@@ -33,7 +34,7 @@ def test_init_without_api_key() -> None:
 
 def test_init_with_api_key(mock_genai: Mock) -> None:
     """測試有 API key 的情況"""
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "GENERATIVE_MODEL": "test-model"}):
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", ConfigKey.USE_MODEL.value: "test-model"}):
         generator = BaseGeminiAIGenerator()
 
         # 驗證 API 設定


### PR DESCRIPTION
將 `BaseGeminiAIGenerator` 中用於讀取生成模型環境變數的
硬編碼字串 "GENERATIVE_MODEL" 替換為 `ConfigKey.USE_MODEL` enum 的值。強制使用使用者設定之模型參數。

同時，`pyproject.toml` 及 `src/commit_assistant/core/project_config.py` 中的專案版本號已更新至 `0.1.11`。相關的單元測試
(`tests/test_base_generator.py`) 也已更新以反映此配置鍵的變更。