### PR TITLE
feat(commit): 允許使用者重新生成 AI 提交訊息

### DIFF
--- a/.commit-assistant/.commit-assistant-config
+++ b/.commit-assistant/.commit-assistant-config
@@ -2,7 +2,7 @@
 ENABLE_COMMIT_ASSISTANT=true
 
 # 模型類型 1. gemini-2.5-flash 2. gemini-2.5-pro 3. gemini-2.0-flash
-USE_MODEL=gemini-2.0-flash
+USE_MODEL=gemini-2.5-flash
 
 # commit style 1. conventional 2. emoji 3. angular 4. custom
 COMMIT_STYLE=angular

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.11"
+version = "0.1.12"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.11"
+    VERSION: str = "0.1.12"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.10"
     LICENSE: str = "Apache-2.0"

--- a/src/commit_assistant/enums/user_choices.py
+++ b/src/commit_assistant/enums/user_choices.py
@@ -4,4 +4,5 @@ from enum import Enum
 class UserChoices(Enum):
     USE_AI_MESSAGE = "✅ 使用 AI 生成的 message"  # 使用 AI message
     EDIT_AI_MESSAGE = "📝 編輯 AI 生成的 message"  # 編輯 AI message
+    REGENERATE_AI_MESSAGE = "🔄 重新生成 AI 產生的 message"  # 重新生成 AI message
     CANCEL_OPERATION = "❌ 取消這次 commit"  # 取消操作


### PR DESCRIPTION
引入了讓使用者重新生成 AI 提交訊息的功能。
過去，若 AI 產生的提交訊息不符預期，使用者只能取消操作並重新開始，效率較低。

此更新在提交訊息確認介面中新增了「🔄 重新生成 AI 產生的 message」選項。當使用者選擇此選項時，工具將不會終止，而是重新呼叫 AI 模型生成新的提交訊息，並再次提供給使用者審核。這個流程會持續進行，直到使用者選擇使用或編輯訊息，或是取消操作為止。

相關變更：
- 將預設的 AI 模型從 `gemini-2.0-flash` 更新為 `gemini-2.5-flash`，以提供更好的生成品質。
- 將專案版本從 `0.1.11` 更新至 `0.1.12`。
- 新增多個測試案例以確保重新生成功能的穩定性。