### PR TITLE
fix(core): 修復 Claude CLI prompt 過長導致的錯誤

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commit-assistant"
-version = "0.1.14"
+version = "0.1.15"
 description = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/commit_assistant/core/base_generator.py
+++ b/src/commit_assistant/core/base_generator.py
@@ -36,10 +36,12 @@ class BaseGeminiAIGenerator:
     def _generate_content(self, prompt: str) -> Optional[str]:
         try:
             if self._use_claude_cli:
-                # 如果使用 claude code
-                # 直接呼叫 claude -p 來生成指定的內容
+                # 如果使用 claude code，直接呼叫 claude -p 來生成指定的內容
+                # 使用 shell=True + stdin 來避免傳入的 prompt 過長的問題
                 result = subprocess.run(
-                    ["claude", "-p", prompt],
+                    "claude -p",
+                    input=prompt,
+                    shell=True,
                     capture_output=True,
                     text=True,
                     encoding="utf-8",

--- a/src/commit_assistant/core/project_config.py
+++ b/src/commit_assistant/core/project_config.py
@@ -19,7 +19,7 @@ from typing import List
 
 class ProjectInfo:
     NAME: str = "commit-assistant"
-    VERSION: str = "0.1.14"
+    VERSION: str = "0.1.15"
     DESCRIPTION: str = "Commit Assistant - 一個幫助你更好寫 commit message 的 CLI 工具"
     PYTHON_REQUIRES: str = ">=3.10"
     LICENSE: str = "Apache-2.0"

--- a/tests/test_base_generator.py
+++ b/tests/test_base_generator.py
@@ -97,7 +97,9 @@ def test_generate_content_with_claude_cli_success() -> None:
 
     assert response == "feat: claude generated message"
     mock_run.assert_called_once_with(
-        ["claude", "-p", "test prompt"],
+        "claude -p",
+        input="test prompt",
+        shell=True,
         capture_output=True,
         text=True,
         encoding="utf-8",


### PR DESCRIPTION
使用 shell=True 搭配 stdin 傳入 prompt，避免直接透過命令列參數
傳遞過長內容時觸發系統參數長度限制的問題。

版本更新至 0.1.15